### PR TITLE
Update xrcedds-suite dependencies

### DIFF
--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -6,24 +6,24 @@ repositories:
   Micro-XRCE-DDS-Agent:
     type: git
     url: https://github.com/eProsima/Micro-XRCE-DDS-Agent
-    version: v2.3.0
+    version: v2.4.0
   Micro-XRCE-DDS-Client:
     type: git
     url: https://github.com/eProsima/Micro-XRCE-DDS-Client.git
-    version: v2.3.0
+    version: v2.4.0
   Micro-XRCE-DDS-Gen:
     type: git
     url: https://github.com/eProsima/Micro-XRCE-DDS-Gen
-    version: v1.1.0
+    version: v2.0.0
   fastcdr:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v1.0.26
+    version: v1.0.27
   fastdds:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
-    version: v2.9.0
+    version: v2.10.1
   foonathan_memory_vendor:
     type: git
     url: https://github.com/eProsima/foonathan_memory_vendor.git
-    version: v1.2.2
+    version: v1.3.0


### PR DESCRIPTION
Update xrcedds-suite dependencies:
* Micro-XRCE-DDS-Agent,v2.4.0;Micro-XRCE-DDS-Client,v2.4.0;Micro-XRCE-DDS-Gen,v2.0.0;fastcdr,v1.0.27;fastdds,v2.10.1;foonathan_memory_vendor,v1.3.0