### PR TITLE
Update fastdds-suite-2.7.x dependencies

### DIFF
--- a/dds-suite.repos
+++ b/dds-suite.repos
@@ -10,7 +10,7 @@ repositories:
   fastcdr:
     type: git
     url: https://github.com/eProsima/Fast-CDR.git
-    version: v1.0.26
+    version: v1.0.27
   fastdds:
     type: git
     url: https://github.com/eProsima/Fast-DDS.git
@@ -22,7 +22,7 @@ repositories:
   fastdds_python:
     type: git
     url: https://github.com/eProsima/Fast-DDS-python.git
-    version: v1.2.0
+    version: v1.2.1
   fastdds_statistics_backend:
     type: git
     url: https://github.com/eProsima/Fast-DDS-statistics-backend.git


### PR DESCRIPTION
Update fastdds-suite-2.7.x dependencies:
* fastcdr,v1.0.27;fastdds_python,v1.2.1